### PR TITLE
Remove non-mandatory supported content components from the body template

### DIFF
--- a/body.es6
+++ b/body.es6
@@ -1,11 +1,4 @@
-/* eslint react/no-danger: 0, id-match: 0 */
 import React, { Component, PropTypes } from 'react';
-
-import DefaultAnimatedPanel from '@economist/component-animatedpanel';
-import DefaultGobbet from '@economist/component-wifgobbet';
-import DefaultImageCaption from '@economist/component-imagecaption';
-import DefaultVideo from '@economist/component-video';
-import DefaultGallery from '@economist/component-gallery';
 
 import { defaultGenerateClassNameList } from './utils';
 
@@ -42,33 +35,29 @@ class ArticleBodyTemplate extends Component {
         Image: 'img',
         Pullquote: 'blockquote',
         ArticleSubHead: 'h3',
-        Gobbet: DefaultGobbet,
-        ImageCaption: DefaultImageCaption,
-        Video: DefaultVideo,
-        AnimatedPanel: DefaultAnimatedPanel,
-        Gallery: DefaultGallery,
       },
       content: [],
     };
   }
 
-  renderContents = (generateClassNameList, variantName, components, contents = []) => {
+  renderContents(generateClassNameList, variantName, components, contents = []) {
     return contents.map((contentPiece, key) => {
       if (typeof contentPiece === 'string') {
         // `dangerouslySetInnerHTML` is used here to support `<a>`, `<em>`
         // `<strong>`, etc, tags within the paragraph strings.
         // See: https://github.com/economist-components/component-articletemplate/pull/11#discussion_r43002610
         return (
-          <p key={key} dangerouslySetInnerHTML={{ __html: contentPiece }} />
+          <p
+            key={key}
+            dangerouslySetInnerHTML={{ __html: contentPiece }} // eslint-disable-line react/no-danger, id-match
+          />
         );
       }
       const SpecifiedComponent = components[contentPiece.component];
       if (!SpecifiedComponent) {
         throw new Error(`Unknown component ${contentPiece.component}`);
       }
-      /* eslint-disable no-invalid-this */
       const children = this.renderContents(generateClassNameList, variantName, components, contentPiece.content);
-      /* eslint-enable no-invalid-this */
       return (
         <SpecifiedComponent
           key={key}

--- a/index.css
+++ b/index.css
@@ -1,5 +1,1 @@
 @import '@economist/component-gridcss';
-@import '@economist/component-animatedpanel';
-@import '@economist/component-wifgobbet';
-@import '@economist/component-video';
-@import '@economist/component-gallery';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@economist/component-articletemplate",
-  "version": "7.0.2",
+  "version": "8.0.0",
   "description": "A template with which to render articles",
   "author": "The Economist (http://economist.com)",
   "license": "ISC",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@economist/component-articletemplate",
-  "version": "7.0.1",
+  "version": "7.0.2",
   "description": "A template with which to render articles",
   "author": "The Economist (http://economist.com)",
   "license": "ISC",

--- a/package.json
+++ b/package.json
@@ -139,12 +139,7 @@
     "watch": "parallelshell 'npm run doc:watch' 'npm run prepublish:watch' 'npm run serve'"
   },
   "dependencies": {
-    "@economist/component-animatedpanel": "^2.1.8",
-    "@economist/component-gallery": "^4.1.0",
     "@economist/component-gridcss": "^2.0.0",
-    "@economist/component-imagecaption": "^1.3.0",
-    "@economist/component-video": "^1.0.0",
-    "@economist/component-wifgobbet": "^1.3.4",
     "lodash.pick": "^3.1.0",
     "react": "^0.14.2"
   },


### PR DESCRIPTION
Remove non-mandatory supported content components from the body template.

Should also fix this: https://github.com/economist-components/component-articletemplate/issues/25