### PR TITLE
fix: handle content supplied as null

### DIFF
--- a/body.es6
+++ b/body.es6
@@ -41,7 +41,10 @@ class ArticleBodyTemplate extends Component {
   }
 
   renderContents(generateClassNameList, variantName, components, contents = []) {
-    contents = contents || [];
+    if (Array.isArray(contents) === false || contents.length === 0) {
+      return []
+    }
+
     return contents.map((contentPiece, key) => {
       if (typeof contentPiece === 'string') {
         // `dangerouslySetInnerHTML` is used here to support `<a>`, `<em>`

--- a/body.es6
+++ b/body.es6
@@ -41,6 +41,7 @@ class ArticleBodyTemplate extends Component {
   }
 
   renderContents(generateClassNameList, variantName, components, contents = []) {
+    contents = contents || [];
     return contents.map((contentPiece, key) => {
       if (typeof contentPiece === 'string') {
         // `dangerouslySetInnerHTML` is used here to support `<a>`, `<em>`

--- a/package.json
+++ b/package.json
@@ -148,6 +148,7 @@
     "@economist/component-font-neutra2": "^1.0.4",
     "@economist/component-font-officina": "^1.0.0",
     "babel": "^5.8.23",
+    "babel-eslint": "^4.1.8",
     "babelify": "^6.3.0",
     "browser-sync": "^2.8.2",
     "browserify": "^11.0.1",


### PR DESCRIPTION
There's been examples of content being supplied as `null` which breaks the page. Small fix to resolve this.